### PR TITLE
Fix white space in previews

### DIFF
--- a/casa-server/src/Casa/Server.hs
+++ b/casa-server/src/Casa/Server.hs
@@ -468,7 +468,10 @@ template Template {body, title} =
                 \color: #05685b;\
                 \word-break: break-all;\
                 \}\
-                \code {word-break: break-all;}\
+                \code {\
+                \white-space: pre-wrap;\
+                \word-break: break-all;\
+                \}\
                 \hr { border: 1px solid #ccc; }")
         body_
           (do body


### PR DESCRIPTION
For an example, compare these two previews:

- https://casa.fpcomplete.com/meta/5066653559d4d6134b022d66a634a17fdcf8db35d28b447e581fec284afa4689
- https://casa.fpcomplete.com/meta/567953433e7b0d149bd99dacea25973aaa9282a15ac55667f47eeb1776b00733