### PR TITLE
Fix #18 Move to `crypton`

### DIFF
--- a/casa-client/casa-client.cabal
+++ b/casa-client/casa-client.cabal
@@ -2,7 +2,7 @@ cabal-version:  1.12
 name:           casa-client
 synopsis:       Client for Casa
 description:    Client for Casa <https://casa.fpcomplete.com/>
-version:        0.0.0
+version:        0.0.2
 copyright:      2018-2019 FP Complete
 author:         Chris Done
 maintainer:     chrisdone@fpcomplete.com
@@ -19,7 +19,7 @@ library
   default-language: Haskell2010
   ghc-options: -Wall
   build-depends:
-      base < 10
+      base >= 4.5 && < 5
     , bytestring
     , base16-bytestring
     , conduit-extra
@@ -33,7 +33,7 @@ library
     , unordered-containers
     , attoparsec
     , unliftio-core
-    , cryptonite
+    , crypton
     , memory
     , network-uri
     , aeson


### PR DESCRIPTION
I am not certain that this is the repository underpinning https://hackage.haskell.org/package/casa-client because:
* the Cabal file on Hackage is for `casa-client-0.0.1`, and this repository has only version `0.0.0`; and
* the Cabal file on Hackage does not identify the `source-repository` etc.

but I am assuming it is. So, I tried to also bring it up to date with the Hackage version before putting through the change to `crypton`.