### PR TITLE
Fix package `casa-server`, and avoid warnings

### DIFF
--- a/casa-server/app/Main.hs
+++ b/casa-server/app/Main.hs
@@ -1,19 +1,33 @@
+{-# HLINT ignore "Use fewer imports"      #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Main entry point.
 
 module Main where
 
-import Casa.Server
-import Control.Concurrent.Async
-import Control.Monad.IO.Class
-import Control.Monad.Trans.Reader
-import Data.Pool
-import Casa.Backend
-import System.Environment
-import Yesod
-import Network.Wai.Handler.Warp (run)
-import Network.Wai.Middleware.Gzip (gzip, def, gzipCheckMime)
+import Casa.Server ( App (..), migrateAll, withDBPool )
+import Control.Concurrent.Async ( concurrently_ )
+import Control.Monad.IO.Class ( liftIO )
+import Control.Monad.Trans.Reader ( runReaderT )
+import Data.Pool ( withResource )
+import Casa.Backend ( manualMigration, runMigration )
+import System.Environment ( getEnv )
+import Yesod ( AuthResult (..), toWaiApp )
+import Network.Wai.Handler.Warp ( run )
+import Network.Wai.Middleware.Gzip ( gzip, gzipCheckMime )
+#if MIN_VERSION_wai_extra(3,1,14)
+import Network.Wai.Middleware.Gzip ( GzipSettings, defaultGzipSettings )
+#else
+import Network.Wai.Middleware.Gzip ( def )
+#endif
+
+#if  MIN_VERSION_wai_extra(3,1,14)
+def :: GzipSettings
+def = defaultGzipSettings
+#endif
 
 -- | Run two servers on different ports, accessing the same app, but
 -- with a different 'appAuthorized' flag. They share the same database
@@ -29,16 +43,22 @@ main = do
         app <- toWaiApp yapp
         run port (gzip def {gzipCheckMime = const True} app)
   withDBPool
-    (\pool -> do
-       withResource
-         pool
-         (runReaderT
-            (do runMigration migrateAll
-                manualMigration))
-       liftIO
-         (concurrently_
-            (runWithAuthAndPort pool authorizedPort Authorized)
-            (runWithAuthAndPort
-               pool
-               unauthorizedPort
-               (Unauthorized "Not authorized on this port"))))
+    ( \pool -> liftIO $ do
+        withResource
+          pool
+          ( runReaderT $ do
+              runMigration migrateAll
+              manualMigration
+          )
+        concurrently_
+          ( runWithAuthAndPort
+              pool
+              authorizedPort
+              Authorized
+          )
+          ( runWithAuthAndPort
+              pool
+              unauthorizedPort
+              (Unauthorized "Not authorized on this port")
+          )
+    )

--- a/casa-server/casa-server.cabal
+++ b/casa-server/casa-server.cabal
@@ -26,7 +26,9 @@ library
   exposed-modules:
     Casa.Server
     Casa.Backend
-  other-modules: Paths_casa_server
+  other-modules:
+    Database.Esqueleto.Compat
+    Paths_casa_server
   hs-source-dirs: src
   default-language: Haskell2010
   ghc-options: -Wall

--- a/casa-server/src/Casa/Server.hs
+++ b/casa-server/src/Casa/Server.hs
@@ -1,9 +1,10 @@
+{-# OPTIONS_GHC -Wno-type-defaults        #-}
+
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
-{-# OPTIONS_GHC -fno-warn-type-defaults #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE LambdaCase #-}
@@ -18,6 +19,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeOperators #-}
 
 -- | Casa content-addressable storage archive server.
 
@@ -38,7 +40,7 @@ import           Casa.Backend
 import           Casa.Types
 import           Control.Applicative
 import           Control.Monad.Logger
-import           Control.Monad.Reader
+import           Control.Monad.Reader ( ask )
 import qualified Crypto.Hash as Crypto
 import qualified Data.Attoparsec.Binary as Atto.B
 import qualified Data.Attoparsec.ByteString as Atto.B
@@ -52,6 +54,7 @@ import           Data.Conduit
 import           Data.Conduit.Attoparsec
 import qualified Data.Conduit.List as CL
 import           Data.Foldable
+import           Data.Functor ( void )
 import           Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NE
 import           Data.Maybe
@@ -60,7 +63,7 @@ import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.Time
 import           Data.Word
-import qualified Database.Esqueleto as E
+import qualified Database.Esqueleto.Compat as E
 import           Lucid
 import           Prelude hiding (log)
 import           System.Environment

--- a/casa-server/src/Database/Esqueleto/Compat.hs
+++ b/casa-server/src/Database/Esqueleto/Compat.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE CPP #-}
+
+{- |
+This module avoids the use of CPP in module "Casa.Server".
+-}
+
+module Database.Esqueleto.Compat
+  ( module E
+  ) where
+
+#if MIN_VERSION_esqueleto(3,5,0)
+import           Database.Esqueleto.Legacy as E
+#else
+import           Database.Esqueleto as E
+#endif


### PR DESCRIPTION
Builds upon:
* #21

and will need to be rebased if that is accepted.

Package `mtl` modules no longer re-export `Control.Monad` (which exports `void`).

`Database.Esqueleto.Legacy` has replaced `Database.Esqueleto`.

The language extension `TypeOperators` is added to avoid warnings about type operator `~`.

Package `wai-extra` has replaced `def` with `defaultGzipSettings`.

The first argument of `withDBPool` has type `(Pool b -> LoggingT IO a)`.

Also adds explicit imports to `Main.hs`.